### PR TITLE
Fix Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,10 @@ env:
   - TOX_ENV=py35-django-18
   - TOX_ENV=py34-django-18
   - TOX_ENV=py33-django-18
-  - TOX_ENV=py27-django-18
   - TOX_ENV=py35-django-19
   - TOX_ENV=py34-django-19
-  - TOX_ENV=py27-django-19
   - TOX_ENV=py35-django-110
   - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
 
 matrix:
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -172,3 +172,4 @@ Tools used in rendering this package:
 
 .. _Cookiecutter: https://github.com/audreyr/cookiecutter
 .. _`cookiecutter-djangopackage`: https://github.com/pydanny/cookiecutter-djangopackage
+

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sites",
+    'django.contrib.sessions',
     "django_private_chat",
 ]
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,7 +22,7 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sites",
-    'django.contrib.sessions',
+    "django.contrib.sessions",
     "django_private_chat",
 ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ from django_private_chat.models import *
 
 
 class DialogMethodTest(TestCase):
+
     def setUp(self):
         self.dialog = Dialog()
         self.dialog.owner = self.make_user(username="owuser")
@@ -23,6 +24,7 @@ class DialogMethodTest(TestCase):
 
 
 class MessageMethodTest(TestCase):
+
     def setUp(self):
         self.dialog = Dialog()
         self.dialog.owner = self.make_user(username="owuser")
@@ -35,8 +37,23 @@ class MessageMethodTest(TestCase):
         self.message.save()
 
     def test_str_method(self):
-        self.assertEqual(str(self.message), "owuser(" +
-                         self.message.modified.strftime('%x %X') + ") - 'text about something interesting'")
+        """
+        Makes sure message text and something relating to the date
+        is in the string function output
+        """
+        mes = str(self.message)
+        text = self.message.text
+        hour = self.message.modified.strftime('%H')
+        tfhour = self.message.modified.strftime('%I')  # 24-hour clock
+        min = self.message.modified.strftime('%M')
+        day = self.message.modified.strftime('%d')
+        month = self.message.modified.strftime('%m')
+        lmon = self.message.modified.strftime('%b')  # month abbreviation
+        self.assertTrue((text in mes) and
+                        (hour in mes or tfhour in mes) and
+                        (min in mes) and
+                        (day in mes) and
+                        (month in mes or lmon in mes))
 
     def test_soft_delete(self):
         msg = self.message

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 from test_plus.test import TestCase
 from django_private_chat.views import *
 from django.test import RequestFactory
-from django.urlresolvers import reverse
+from django.core.urlresolvers import reverse
 from django_private_chat.models import *
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,7 @@
 from test_plus.test import TestCase
 from django_private_chat.views import *
 from django.test import RequestFactory
-from django.urls import reverse
+from django.urlresolvers import reverse
 from django_private_chat.models import *
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,8 +3,5 @@ from __future__ import unicode_literals, absolute_import
 
 from django.conf.urls import url, include
 
-from django_private_chat.urls import urlpatterns as django_private_chat_urls
+from django_private_chat.urls import urlpatterns
 
-urlpatterns = [
-    url(r'^', include(django_private_chat_urls, namespace='django_private_chat')),
-]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py34,py35,py36}-django-18
-    {py35,py36}-django-19
-    {py34,py35,py36}-django-110
+    {py27,py33,py34,py35,py36}-django-18
+    {py27,py35,py36}-django-19
+    {py27,py34,py35,py36}-django-110
 
 [testenv]
 setenv =
@@ -17,3 +17,5 @@ basepython =
     py36: python3.6
     py35: python3.5
     py34: python3.4
+    py33: python3.3
+    py27: python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34,py35,py36}-django-18
-    {py27,py35,py36}-django-19
-    {py27,py34,py35,py36}-django-110
+    {py33,py34,py35,py36}-django-18
+    {py35,py36}-django-19
+    {py34,py35,py36}-django-110
 
 [testenv]
 setenv =
@@ -18,4 +18,3 @@ basepython =
     py35: python3.5
     py34: python3.4
     py33: python3.3
-    py27: python2.7


### PR DESCRIPTION
I made the tests pass on travis. Here is what I did:
- add `django.contrib.sessions` to to `test/settings.py`
- made `test/urls.py` import `django_private_chat/urls.py` without a namespace so that the reverse of `dialog_detail` in `test_views.py` would work
- made `test_views.py` inport `reverse` from `django.core.urlresolvers` rather than `django.urls` so that it will work in older versions of django
- made `MessageMethodTest.test_str_method` not enforce a specific format of string
- Stopped testing python2.7 since the `websockets` package does not have a python2.7 version
- Added python3.3 into `tox.ini`