### PR TITLE
Fix example website

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -4,3 +4,4 @@
 django-private-chat>=0.1.0
 Django==1.10.5
 django-debug-toolbar==1.6
+packaging==16.8

--- a/example/templates/django_private_chat/dialogs.html
+++ b/example/templates/django_private_chat/dialogs.html
@@ -236,7 +236,7 @@
                             } else {
                                 if ($("#user-"+username).length == 0){
                                     var new_button = $(''+
-                                        '<a href="{% url 'dialogs_detail' username %}" ' +
+                                        '<a href="/'+ username + '"' +
                                         'id="user-'+username+'" class="btn btn-danger">{% trans "Chat with" %} '+username+'</a>');
                                     $("#user-list-div").find("ul").append()
                                 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -43,17 +43,24 @@ class MessageMethodTest(TestCase):
         """
         mes = str(self.message)
         text = self.message.text
-        hour = self.message.modified.strftime('%H')
-        tfhour = self.message.modified.strftime('%I')  # 24-hour clock
         min = self.message.modified.strftime('%M')
         day = self.message.modified.strftime('%d')
+        hour = self.message.modified.strftime('%H')
+        tfhour = self.message.modified.strftime('%I')  # 24-hour clock
         month = self.message.modified.strftime('%m')
         lmon = self.message.modified.strftime('%b')  # month abbreviation
-        self.assertTrue((text in mes) and
-                        (hour in mes or tfhour in mes) and
-                        (min in mes) and
-                        (day in mes) and
-                        (month in mes or lmon in mes))
+        # remove 0 padding
+        min = min.lstrip("0").replace(" 0", " ")
+        day = day.lstrip("0").replace(" 0", " ")
+        hour = hour.lstrip("0").replace(" 0", " ")
+        tfhour = tfhour.lstrip("0").replace(" 0", " ")
+        month = month.lstrip("0").replace(" 0", " ")
+
+        self.assertIn(text, mes)
+        self.assertIn(min, mes)
+        self.assertIn(day, mes)
+        self.assertTrue(hour in mes or tfhour in mes)
+        self.assertTrue(month in mes or lmon in mes)
 
     def test_soft_delete(self):
         msg = self.message


### PR DESCRIPTION
There were two bugs I found in the example project:
* The `settings.py` imported the packaging module and the `requirements.txt` did not install packaging
* There was a reverse match error on the dialogue detail page because a variable was defined in javascript but not in the django templating langue. 

For the second one, I just took the django templating language `url` tag out of the javascript because it would be hard to find a solutions using that tag. Instead, I used a relative url which, unlike the `url` tag, could fail if the `urls.py` gets updated. I think that that risk of failure is worth not having to exchange variables between javascript and django templating language. 

Also I fixed a bug in one of the tests I changed in #2 which had a bug to do with zero padding of `datetimes`.