### PR TITLE
Added WSS support to run_chat_server using Python ssl module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ output/*/index.html
 
 # Sphinx
 docs/_build
+
+# Windows
+Include
+Scripts
+tcl
+pip-selfcheck.json

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 
 .. image:: https://codecov.io/gh/Bearle/django-private-chat/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/Bearle/django-private-chat
-    
+
 Please also check out our another package https://github.com/Bearle/django_mail_admin
 
 Django one-to-one Websocket-based Asyncio-handled chat, developed by Bearle team
@@ -127,6 +127,13 @@ Now you can start a dialog using ::
     /dialogs/some_existing_username
 
 
+To create a WSS (TLS) server instead:
+
+.. code-block:: python
+
+    python manage.py run_chat_server "path/to/cert.pem"
+
+(also works with uvloop). The "cert.pem" file should be a plaintext PEM file containing first a private key, then a certificate (may be a concatenation of a .key and a .crt file).
 
 Features
 --------
@@ -138,6 +145,8 @@ Features
 -:white_check_mark: One-to-one user chat
 
 -:white_check_mark: Works using WebSockets
+
+-:white_check_mark: Works (optionally) using WSS (TLS) connections (disclaimer - security not guaranteed)
 
 -:white_check_mark: Displays online/offline status
 

--- a/django_private_chat/admin.py
+++ b/django_private_chat/admin.py
@@ -6,6 +6,8 @@ from .models import Dialog, Message
 class DialogAdmin(admin.ModelAdmin):
     list_display = ('id', 'created', 'modified', 'owner', 'opponent')
     list_filter = ('created', 'modified', 'owner', 'opponent')
+
+
 admin.site.register(Dialog, DialogAdmin)
 
 
@@ -20,4 +22,6 @@ class MessageAdmin(admin.ModelAdmin):
         'text',
     )
     list_filter = ('created', 'modified', 'is_removed', 'dialog', 'sender')
+
+
 admin.site.register(Message, MessageAdmin)

--- a/django_private_chat/handlers.py
+++ b/django_private_chat/handlers.py
@@ -228,7 +228,7 @@ def read_message_handler(stream):
                 if message:
                     message.read = True
                     message.save()
-                    logger.debug('Message '+str(message_id)+' is now read')
+                    logger.debug('Message ' + str(message_id) + ' is now read')
                     opponent_socket = ws_connections.get((user_opponent, user_owner.username))
                     if opponent_socket:
                         yield from target_message(opponent_socket,
@@ -267,7 +267,8 @@ def main_handler(websocket, path):
         try:
             while websocket.open:
                 data = yield from websocket.recv()
-                if not data: continue
+                if not data:
+                    continue
                 logger.debug(data)
                 try:
                     yield from router.MessageRouter(data)()

--- a/django_private_chat/models.py
+++ b/django_private_chat/models.py
@@ -7,6 +7,7 @@ from django.template.defaultfilters import date as dj_date
 from django.utils.translation import ugettext as _
 from django.utils.timezone import localtime
 
+
 class Dialog(TimeStampedModel):
     owner = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_("Dialog owner"), related_name="selfDialogs",
                               on_delete=models.CASCADE)


### PR DESCRIPTION
- Used Python's built-in ssl module to add running a WSS server (instead of WS) as a command-line option on run_chat_server (both versions)
- Modified README.rst with this change
- Made a few other minor changes to pass some flake8 tests
- Added to .gitignore some files which seem to be generated on my (windows) setup

I tried running tests but some of them seemed to fail based on files I hadn't touched. Not used to Github/etc. so let me know if I've done anything wrong.