### PR TITLE
AttributeError in read_message_handler

### DIFF
--- a/django_private_chat/handlers.py
+++ b/django_private_chat/handlers.py
@@ -224,7 +224,7 @@ def read_message_handler(stream):
         if session_id and user_opponent and message_id is not None:
             user_owner = get_user_from_session(session_id)
             if user_owner:
-                message = models.Message.filter(id=message_id).first()
+                message = models.Message.objects.filter(id=message_id).first()
                 if message:
                     message.read = True
                     message.save()


### PR DESCRIPTION
It solves an error in the read_message handler by which the messages were not marked as read.