### PR TITLE
Fix run_chat_server for python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django-model-utils==2.6.1
 # Additional requirements go here
 django-braces==1.12.0
-websockets==3.2
+websockets==8.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=["django-model-utils>=2.6.1","django-braces>=1.10.0",
-                      "websockets==3.2"],
+                      "websockets==8.1"],
     license="ISCL",
     zip_safe=False,
     keywords='django-private-chat',
@@ -73,5 +73,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )


### PR DESCRIPTION
Websockets upgraded to 8.1, Websockets 3.2 uses 'async' which is a reserved keyword as of Python 3.7

Closes #41 
